### PR TITLE
Update config.yaml.example

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -10,4 +10,4 @@ database:
     - http://hkroger.info/thermometer/api/measurements
   key: <key here>
   client_id: <client id here>
-buffer_file: "/var/lib/nokeval-reader/measurements.sqlite3"
+buffer_file: "/var/lib/nokeval_reader/measurements.sqlite3"


### PR DESCRIPTION
Match the buffer_file with what the debian build creates.

Another option is to update the debian build file to create the path with the dash instead of underscore. But as underscore has been used for everything else this makes the most sense to me.
